### PR TITLE
decorator: make an error more verbose

### DIFF
--- a/decorator/restorer.go
+++ b/decorator/restorer.go
@@ -267,7 +267,7 @@ func (r *FileRestorer) updateImports() error {
 		}
 		name, err := r.Resolver.ResolvePackage(path)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not resolve package %s: %w", path, err)
 		}
 		resolved[path] = name
 	}


### PR DESCRIPTION
Without specifying which package could not be found, this error is not actionable for users.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>